### PR TITLE
feat: add flagged autolinking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,3 +38,7 @@ jobs:
       - name: Run spec for expo config plugin
         working-directory: example
         run: node ../test/test-config-plugin.js
+
+      - name: Run spec for flagged autolinking
+        working-directory: example
+        run: node ../test/test-autolinking.js

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ Example for flags.yml definition:
 flags:
   featureWithNativeStuff:
     value: false
-    nativeModules:
+    modules:
       - react-native-device-info
 ```
 
 In the above example, `react-native-device-info` would be excluded from autolinking. If you want to allow builds to occur on a specific branch, you can specify it:
 
 ```yaml
-nativeModules:
+modules:
   - react-native-device-info:
       branch: some-branch-with-build
 ```

--- a/README.md
+++ b/README.md
@@ -85,3 +85,6 @@ Locally-referenced modules aren't currently supported (until [this 'exclude' exc
 - [ ] allow for referencing flag values from native code on iOS or Android
 - [x] allow for tree-shaking of the JS bundle and dead code path elimination
 - [x] allow for typescript to see the specific flags available
+- [ ] add metro resolver w/ proxy to surface better flagged autolinking error messages
+- [ ] add android integration spec for flagged autolinking
+- [ ] doc site & readme cleanup to reference

--- a/README.md
+++ b/README.md
@@ -51,6 +51,26 @@ To benefit from tree shaking, add the babel plugin to your project's babel confi
 
 The `flagsModule` path must match the runtime `mergePath` in your committed flags.yml file. This plugin replaces the `BuildFlags` imports with the literal boolean values which allows the build pipeline to strip unreachable paths.
 
+### Flagged Autolinking
+
+If your feature relies on native module behaviour, you may want to avoid linking that module if the build flag is off. To do so, specify the absolute name or relative path to the module in the base definition for your flag:
+
+Example for flags.yml definition:
+
+```yaml
+flags:
+  featureWithNativeStuff:
+    value: false
+    nativeModules:
+      - react-native-device-info
+      - ./modules/my-local-module # needs expo PR https://github.com/expo/expo/blob/24d5ae5f288013df19ac09a3406c6a507d781ddb/packages/expo-modules-autolinking/src/autolinking/findModules.ts#L52
+```
+
+Implementation:
+
+- our config plugin can take props that enable this behaviour during prebuild
+- you wrap your metro config if you want to get runtime guidance about using unavailable imports for flagged features
+
 ## Goals
 
 - [x] allow defining a base set of flags that are available at runtime in one place

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ flags:
   featureWithNativeStuff:
     value: false
     nativeModules:
-      - react-native-device-info
+      - react-native-device-info:
+          branch: some-branch-with-build
       - ./modules/my-local-module # needs expo PR https://github.com/expo/expo/blob/24d5ae5f288013df19ac09a3406c6a507d781ddb/packages/expo-modules-autolinking/src/autolinking/findModules.ts#L52
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,15 +62,18 @@ flags:
   featureWithNativeStuff:
     value: false
     nativeModules:
-      - react-native-device-info:
-          branch: some-branch-with-build
-      - ./modules/my-local-module # needs expo PR https://github.com/expo/expo/blob/24d5ae5f288013df19ac09a3406c6a507d781ddb/packages/expo-modules-autolinking/src/autolinking/findModules.ts#L52
+      - react-native-device-info
 ```
 
-Implementation:
+In the above example, `react-native-device-info` would be excluded from autolinking. If you want to allow builds to occur on a specific branch, you can specify it:
 
-- our config plugin can take props that enable this behaviour during prebuild
-- you wrap your metro config if you want to get runtime guidance about using unavailable imports for flagged features
+```yaml
+nativeModules:
+  - react-native-device-info:
+      branch: some-branch-with-build
+```
+
+Locally-referenced modules aren't currently supported (until [this 'exclude' exclusion](https://github.com/expo/expo/blob/24d5ae5f288013df19ac09a3406c6a507d781ddb/packages/expo-modules-autolinking/src/autolinking/findModules.ts#L52) can be overridden).
 
 ## Goals
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@types/babel__helper-plugin-utils": "^7.10.3",
         "@types/node": "^22.6.1",
         "jest": "^29.7.0",
+        "pod-lockfile": "^1.2.2",
         "typescript": "^5"
       },
       "peerDependencies": {
@@ -4661,6 +4662,15 @@
       "dev": true,
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/pod-lockfile": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/pod-lockfile/-/pod-lockfile-1.2.2.tgz",
+      "integrity": "sha512-XI83c8BavRBfqbDxlIH4nLOt7xUF1ghXAjybVPEfhltk/wR+I8M8/eMwppCHzfQpP2F9DjsYkzRTsEDjEQI8Bg==",
+      "dev": true,
+      "bin": {
+        "pod-lockfile": "bin/pod-lockfile"
       }
     },
     "node_modules/pretty-format": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/babel__core": "^7.20.5",
         "@types/babel__helper-plugin-utils": "^7.10.3",
         "@types/node": "^22.6.1",
+        "expo-native-lockfiles": "^0.2.0",
         "jest": "^29.7.0",
         "pod-lockfile": "^1.2.2",
         "typescript": "^5"
@@ -3276,6 +3277,18 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/expo-native-lockfiles": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/expo-native-lockfiles/-/expo-native-lockfiles-0.2.0.tgz",
+      "integrity": "sha512-EJqEGeuVSjMcsnipPWZEnk84l/Yc909vE3N6+tmBy4KtheO6L39vDA3jFA13egkQzdMiXF1eZSnFudeGRAvncw==",
+      "dev": true,
+      "dependencies": {
+        "pod-lockfile": "^1.2.2"
+      },
+      "bin": {
+        "native-lock": "cli/native-lock.sh"
       }
     },
     "node_modules/fast-json-stable-stringify": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/babel__core": "^7.20.5",
     "@types/babel__helper-plugin-utils": "^7.10.3",
     "@types/node": "^22.6.1",
+    "expo-native-lockfiles": "^0.2.0",
     "jest": "^29.7.0",
     "pod-lockfile": "^1.2.2",
     "typescript": "^5"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "./node_modules/.bin/jest && ./test/setup.sh && cd example && ../test/test-overrides.sh && node ../test/test-babel-plugin.js && node ../test/test-config-plugin.js"
+    "test": "npm run test:unit && ./test/setup.sh && cd example && ../test/test-overrides.sh && node ../test/test-babel-plugin.js && node ../test/test-config-plugin.js",
+    "test:unit": "./node_modules/.bin/jest"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/babel__helper-plugin-utils": "^7.10.3",
     "@types/node": "^22.6.1",
     "jest": "^29.7.0",
+    "pod-lockfile": "^1.2.2",
     "typescript": "^5"
   },
   "dependencies": {
@@ -35,7 +36,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "npm run test:unit && ./test/setup.sh && cd example && ../test/test-overrides.sh && node ../test/test-babel-plugin.js && node ../test/test-config-plugin.js",
+    "test": "npm run test:unit && ./test/setup.sh && cd example && ../test/test-overrides.sh && node ../test/test-babel-plugin.js && node ../test/test-config-plugin.js && node ../test/test-autolinking.js",
     "test:unit": "./node_modules/.bin/jest"
   }
 }

--- a/src/api/fixtures/flags.yml
+++ b/src/api/fixtures/flags.yml
@@ -1,11 +1,15 @@
 mergePath: "constants/buildFlags.ts"
 flags:
-  featureInDevelqopment:
+  featureInDevelopment:
     value: false
     meta:
       team: "platform"
     nativeModules:
-      - "react-native-device-info"
+      - react-native-device-info
+      - do-not-exclude-me:
+          branch: feature-in-dev-build-branch
+      - exclude-me:
+          branch: not-my-branch
   publishedFeature:
     value: true
     meta:

--- a/src/api/fixtures/flags.yml
+++ b/src/api/fixtures/flags.yml
@@ -4,7 +4,7 @@ flags:
     value: false
     meta:
       team: "platform"
-    nativeModules:
+    modules:
       - react-native-device-info
       - do-not-exclude-me:
           branch: feature-in-dev-build-branch
@@ -14,5 +14,5 @@ flags:
     value: true
     meta:
       team: "growth"
-    nativeModules:
+    modules:
       - "react-native-mmkv"

--- a/src/api/fixtures/flags.yml
+++ b/src/api/fixtures/flags.yml
@@ -1,0 +1,14 @@
+mergePath: "constants/buildFlags.ts"
+flags:
+  featureInDevelqopment:
+    value: false
+    meta:
+      team: "platform"
+    nativeModules:
+      - "react-native-device-info"
+  publishedFeature:
+    value: true
+    meta:
+      team: "growth"
+    nativeModules:
+      - "react-native-mmkv"

--- a/src/api/readConfig.spec.ts
+++ b/src/api/readConfig.spec.ts
@@ -1,0 +1,24 @@
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import * as fs from "fs/promises";
+import { readConfigModuleExclusions } from "./readConfig";
+import { readFile } from "fs";
+
+jest.mock("fs/promises", () => ({
+  readFile: jest.fn(() => Promise.resolve()),
+}));
+
+const fsActual: any = jest.requireActual("fs/promises");
+
+describe("readConfigModuleExclusions", () => {
+  beforeEach(async () => {
+    const yaml = await fsActual.readFile("src/api/fixtures/flags.yml", {
+      encoding: "utf-8",
+    });
+    jest.spyOn(fs, "readFile").mockResolvedValue(yaml);
+  });
+
+  it("should return array of strings for modules for false flags", async () => {
+    const exclusions = await readConfigModuleExclusions();
+    expect(exclusions).toEqual(["react-native-device-info"]);
+  });
+});

--- a/src/api/readConfig.ts
+++ b/src/api/readConfig.ts
@@ -53,10 +53,10 @@ export const readConfigModuleExclusions = async (
   return Object.keys(flags)
     .filter((flag) => !flags[flag].value)
     .reduce((acc, flag) => {
-      if (flags[flag].nativeModules && !flagOverrides?.includes(flag)) {
+      if (flags[flag].modules && !flagOverrides?.includes(flag)) {
         return [
           ...acc,
-          ...flags[flag].nativeModules
+          ...flags[flag].modules
             .map((mod) => {
               if (typeof mod === "string") {
                 return mod;

--- a/src/api/readConfig.ts
+++ b/src/api/readConfig.ts
@@ -34,3 +34,25 @@ export const readConfig = async (): Promise<FlagsConfig> => {
     process.exit(1);
   }
 };
+
+export const readConfigModuleExclusions = async (): Promise<string[]> => {
+  const { flags } = await readConfig();
+  return Object.keys(flags)
+    .filter((flag) => !flags[flag].value)
+    .reduce((acc, flag) => {
+      if (flags[flag].nativeModules) {
+        return [
+          ...acc,
+          ...flags[flag].nativeModules
+            .map((mod) => {
+              if (typeof mod === "string") {
+                return mod;
+              }
+              return mod.branch;
+            })
+            .filter((mod) => !!mod),
+        ];
+      }
+      return acc;
+    }, [] as string[]);
+};

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,12 +1,12 @@
 type OTAFilter = { branches: string[] };
-type NativeModuleConfig = string | { branch: string };
+type ModuleConfig = string | { branch: string };
 export type FlagMap = Record<
   string,
   {
     value: boolean;
     meta: any;
     ota?: OTAFilter;
-    nativeModules?: NativeModuleConfig[];
+    modules?: ModuleConfig[];
   }
 >;
 export type FlagsConfig = {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,7 +1,13 @@
 type OTAFilter = { branches: string[] };
+type NativeModuleConfig = string | { branch: string };
 export type FlagMap = Record<
   string,
-  { value: boolean; meta: any; ota?: OTAFilter }
+  {
+    value: boolean;
+    meta: any;
+    ota?: OTAFilter;
+    nativeModules?: NativeModuleConfig[];
+  }
 >;
 export type FlagsConfig = {
   mergePath: string;

--- a/src/config-plugin/fixtures/Podfile
+++ b/src/config-plugin/fixtures/Podfile
@@ -1,0 +1,79 @@
+require File.join(File.dirname(`node --print "require.resolve('expo/package.json')"`), "scripts/autolinking")
+require File.join(File.dirname(`node --print "require.resolve('react-native/package.json')"`), "scripts/react_native_pods")
+
+require 'json'
+podfile_properties = JSON.parse(File.read(File.join(__dir__, 'Podfile.properties.json'))) rescue {}
+
+ENV['RCT_NEW_ARCH_ENABLED'] = podfile_properties['newArchEnabled'] == 'true' ? '1' : '0'
+ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] = podfile_properties['EX_DEV_CLIENT_NETWORK_INSPECTOR']
+
+use_autolinking_method_symbol = ('use' + '_native' + '_modules!').to_sym
+origin_autolinking_method = self.method(use_autolinking_method_symbol)
+self.define_singleton_method(use_autolinking_method_symbol) do |*args|
+  if ENV['EXPO_UNSTABLE_CORE_AUTOLINKING'] == '1'
+    Pod::UI.puts('Using expo-modules-autolinking as core autolinking source'.green)
+    config_command = [
+      'node',
+      '--no-warnings',
+      '--eval',
+      'require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo/package.json\')] }))(process.argv.slice(1))',
+      'react-native-config',
+      '--json',
+      '--platform',
+      'ios'
+    ]
+    origin_autolinking_method.call(config_command)
+  else
+    origin_autolinking_method.call()
+  end
+end
+
+platform :ios, podfile_properties['ios.deploymentTarget'] || '13.4'
+install! 'cocoapods',
+  :deterministic_uuids => false
+
+prepare_react_native_project!
+
+target 'example' do
+  use_expo_modules!
+  config = use_native_modules!
+
+  use_frameworks! :linkage => podfile_properties['ios.useFrameworks'].to_sym if podfile_properties['ios.useFrameworks']
+  use_frameworks! :linkage => ENV['USE_FRAMEWORKS'].to_sym if ENV['USE_FRAMEWORKS']
+
+  use_react_native!(
+    :path => config[:reactNativePath],
+    :hermes_enabled => podfile_properties['expo.jsEngine'] == nil || podfile_properties['expo.jsEngine'] == 'hermes',
+    # An absolute path to your application root.
+    :app_path => "#{Pod::Config.instance.installation_root}/..",
+    :privacy_file_aggregation_enabled => podfile_properties['apple.privacyManifestAggregationEnabled'] != 'false',
+  )
+
+  post_install do |installer|
+    react_native_post_install(
+      installer,
+      config[:reactNativePath],
+      :mac_catalyst_enabled => false,
+      :ccache_enabled => podfile_properties['apple.ccacheEnabled'] == 'true',
+    )
+
+    # This is necessary for Xcode 14, because it signs resource bundles by default
+    # when building for devices.
+    installer.target_installation_results.pod_target_installation_results
+      .each do |pod_name, target_installation_result|
+      target_installation_result.resource_bundle_targets.each do |resource_bundle_target|
+        resource_bundle_target.build_configurations.each do |config|
+          config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
+        end
+      end
+    end
+  end
+
+  post_integrate do |installer|
+    begin
+      expo_patch_react_imports!(installer)
+    rescue => e
+      Pod::UI.warn e
+    end
+  end
+end

--- a/src/config-plugin/fixtures/settings.gradle
+++ b/src/config-plugin/fixtures/settings.gradle
@@ -1,0 +1,66 @@
+pluginManagement {
+  def version = providers.exec {
+    commandLine("node", "-e", "console.log(require('react-native/package.json').version);")
+  }.standardOutput.asText.get().trim()
+  def (_, reactNativeMinor, reactNativePatch) = version.split("-")[0].tokenize('.').collect { it.toInteger() }
+
+  includeBuild(new File(["node", "--print", "require.resolve('@react-native/gradle-plugin/package.json')"].execute(null, rootDir).text.trim()).getParentFile().toString())
+  if(reactNativeMinor == 74 && reactNativePatch <= 3){
+    includeBuild("react-settings-plugin")
+  }
+}
+
+plugins { id("com.facebook.react.settings") }
+
+def getRNMinorVersion() {
+  def version = providers.exec {
+    commandLine("node", "-e", "console.log(require('react-native/package.json').version);")
+  }.standardOutput.asText.get().trim()
+
+  def coreVersion = version.split("-")[0]
+  def (major, minor, patch) = coreVersion.tokenize('.').collect { it.toInteger() }
+
+  return minor
+}
+
+if (getRNMinorVersion() >= 75) {
+  extensions.configure(com.facebook.react.ReactSettingsExtension) { ex ->
+    if (System.getenv('EXPO_UNSTABLE_CORE_AUTOLINKING') == '1') {
+      println('\u001B[32mUsing expo-modules-autolinking as core autolinking source\u001B[0m')
+      def command = [
+        'node',
+        '--no-warnings',
+        '--eval',
+        'require(require.resolve(\'expo-modules-autolinking\', { paths: [require.resolve(\'expo/package.json\')] }))(process.argv.slice(1))',
+        'react-native-config',
+        '--json',
+        '--platform',
+        'android'
+      ].toList()
+      ex.autolinkLibrariesFromCommand(command)
+    } else {
+      ex.autolinkLibrariesFromCommand()
+    }
+  }
+}
+
+rootProject.name = 'example'
+
+dependencyResolutionManagement {
+  versionCatalogs {
+    reactAndroidLibs {
+      from(files(new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim(), "../gradle/libs.versions.toml")))
+    }
+  }
+}
+
+apply from: new File(["node", "--print", "require.resolve('expo/package.json')"].execute(null, rootDir).text.trim(), "../scripts/autolinking.gradle");
+useExpoModules()
+
+if (getRNMinorVersion() < 75) {
+  apply from: new File(["node", "--print", "require.resolve('@react-native-community/cli-platform-android/package.json', { paths: [require.resolve('react-native/package.json')] })"].execute(null, rootDir).text.trim(), "../native_modules.gradle");
+  applyNativeModulesSettingsGradle(settings)
+}
+
+include ':app'
+includeBuild(new File(["node", "--print", "require.resolve('@react-native/gradle-plugin/package.json', { paths: [require.resolve('react-native/package.json')] })"].execute(null, rootDir).text.trim()).getParentFile())

--- a/src/config-plugin/index.ts
+++ b/src/config-plugin/index.ts
@@ -78,8 +78,10 @@ type ConfigPluginProps =
   | { skipBundleOverride?: boolean; flaggedAutolinking?: boolean }
   | undefined;
 
-const withBuildFlags: ConfigPlugin<ConfigPluginProps> = (config, props) => {
-  const flags = parseEnvFlags();
+type WithBuildFlagsProps = { skipBundleOverride?: boolean; flags: string[] };
+
+const withBuildFlags: ConfigPlugin<WithBuildFlagsProps> = (config, props) => {
+  const flags = props.flags;
   if (!flags.length) {
     return props?.skipBundleOverride
       ? config
@@ -100,12 +102,13 @@ const withBuildFlagsAndLinking: ConfigPlugin<ConfigPluginProps> = (
   props
 ) => {
   let mergedConfig = config;
+  const flags = parseEnvFlags();
 
   if (props?.flaggedAutolinking) {
-    mergedConfig = withFlaggedAutolinking(mergedConfig);
+    mergedConfig = withFlaggedAutolinking(mergedConfig, { flags });
   }
 
-  return withBuildFlags(config, props);
+  return withBuildFlags(config, { ...props, flags });
 };
 
 export default createRunOncePlugin(

--- a/src/config-plugin/withFlaggedAutolinking.spec.ts
+++ b/src/config-plugin/withFlaggedAutolinking.spec.ts
@@ -1,0 +1,29 @@
+import fs from "fs";
+import { jest, describe, it, expect, beforeEach } from "@jest/globals";
+import { updatePodfileAutolinkCall } from "./withFlaggedAutolinking";
+
+const podfileContents = fs.readFileSync(
+  "src/config-plugin/fixtures/Podfile",
+  "utf8"
+);
+
+describe("withFlaggedAutolinking", () => {
+  describe("updatePodfileAutolinkCall", () => {
+    it("should replace use_expo_modules! with exclude options in call", () => {
+      const updatedContents = updatePodfileAutolinkCall(podfileContents, {
+        exclude: "react-native-device-info",
+      });
+      const updatedLine = updatedContents
+        .split("\n")
+        .find((line) =>
+          line
+            .trim()
+            .startsWith(
+              'use_expo_modules!({ exclude: ["react-native-device-info"] })'
+            )
+        );
+
+      expect(updatedLine).toBeTruthy();
+    });
+  });
+});

--- a/src/config-plugin/withFlaggedAutolinking.spec.ts
+++ b/src/config-plugin/withFlaggedAutolinking.spec.ts
@@ -1,14 +1,17 @@
 import fs from "fs";
 import { jest, describe, it, expect, beforeEach } from "@jest/globals";
-import { updatePodfileAutolinkCall } from "./withFlaggedAutolinking";
-
-const podfileContents = fs.readFileSync(
-  "src/config-plugin/fixtures/Podfile",
-  "utf8"
-);
+import {
+  updatePodfileAutolinkCall,
+  updateGradleAutolinkCall,
+} from "./withFlaggedAutolinking";
 
 describe("withFlaggedAutolinking", () => {
   describe("updatePodfileAutolinkCall", () => {
+    const podfileContents = fs.readFileSync(
+      "src/config-plugin/fixtures/Podfile",
+      "utf8"
+    );
+
     it("should replace use_expo_modules! with exclude options in call", () => {
       const updatedContents = updatePodfileAutolinkCall(podfileContents, {
         exclude: "react-native-device-info",
@@ -24,6 +27,31 @@ describe("withFlaggedAutolinking", () => {
         );
 
       expect(updatedLine).toBeTruthy();
+    });
+  });
+
+  describe("updateGradleAutolinkCall", () => {
+    const gradleSettingsContents = fs.readFileSync(
+      "src/config-plugin/fixtures/settings.gradle",
+      "utf8"
+    );
+
+    it("should replace useExpoModules() with exclude options in call", () => {
+      const updatedContents = updateGradleAutolinkCall(gradleSettingsContents, {
+        exclude: "react-native-device-info",
+      });
+      const lines = updatedContents.split("\n");
+      const updatedLine = lines.findIndex((line) =>
+        line.trim().startsWith("useExpoModules")
+      );
+
+      const matchLines = [lines[updatedLine]];
+      matchLines.push(lines[updatedLine + 1]);
+      matchLines.push(lines[updatedLine + 2]);
+
+      expect(matchLines.join("\n").trim()).toBe(
+        "useExpoModules {\n  exclude = 'react-native-device-info'\n}"
+      );
     });
   });
 });

--- a/src/config-plugin/withFlaggedAutolinking.spec.ts
+++ b/src/config-plugin/withFlaggedAutolinking.spec.ts
@@ -14,7 +14,7 @@ describe("withFlaggedAutolinking", () => {
 
     it("should replace use_expo_modules! with exclude options in call", () => {
       const updatedContents = updatePodfileAutolinkCall(podfileContents, {
-        exclude: "react-native-device-info",
+        exclude: ["react-native-device-info"],
       });
       const updatedLine = updatedContents
         .split("\n")
@@ -38,19 +38,15 @@ describe("withFlaggedAutolinking", () => {
 
     it("should replace useExpoModules() with exclude options in call", () => {
       const updatedContents = updateGradleAutolinkCall(gradleSettingsContents, {
-        exclude: "react-native-device-info",
+        exclude: ["react-native-device-info", "some-other-module"],
       });
       const lines = updatedContents.split("\n");
-      const updatedLine = lines.findIndex((line) =>
+      const updatedLine = lines.find((line) =>
         line.trim().startsWith("useExpoModules")
       );
 
-      const matchLines = [lines[updatedLine]];
-      matchLines.push(lines[updatedLine + 1]);
-      matchLines.push(lines[updatedLine + 2]);
-
-      expect(matchLines.join("\n").trim()).toBe(
-        "useExpoModules {\n  exclude = 'react-native-device-info'\n}"
+      expect(updatedLine).toBe(
+        `useExpoModules(exclude: ["react-native-device-info","some-other-module"])`
       );
     });
   });

--- a/src/config-plugin/withFlaggedAutolinking.ts
+++ b/src/config-plugin/withFlaggedAutolinking.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { ConfigPlugin, withDangerousMod } from "@expo/config-plugins";
+import { readConfigModuleExclusions } from "../api/readConfig";
 
 const withFlaggedAutolinkingForApple: ConfigPlugin = (config) => {
   return withDangerousMod(config, [
@@ -11,10 +12,35 @@ const withFlaggedAutolinkingForApple: ConfigPlugin = (config) => {
         "Podfile"
       );
       let contents = await fs.promises.readFile(podfile, "utf8");
-
+      const exclude = await getExclusions();
+      contents = updatePodfileAutolinkCall(contents, { exclude });
+      await fs.promises.writeFile(podfile, contents, "utf8");
       return config;
     },
   ]);
+};
+
+const withFlaggedAutolinkingForAndroid: ConfigPlugin = (config) => {
+  return withDangerousMod(config, [
+    "ios",
+    async (config) => {
+      const gradleSettings = path.join(
+        config.modRequest.platformProjectRoot,
+        "settings.gradle"
+      );
+      let contents = await fs.promises.readFile(gradleSettings, "utf8");
+      const exclude = await getExclusions();
+      contents = updateGradleAutolinkCall(contents, { exclude });
+      await fs.promises.writeFile(gradleSettings, contents, "utf8");
+      return config;
+    },
+  ]);
+};
+
+export const withFlaggedAutolinking: ConfigPlugin = (config) => {
+  return withFlaggedAutolinkingForAndroid(
+    withFlaggedAutolinkingForApple(config)
+  );
 };
 
 export function updatePodfileAutolinkCall(
@@ -36,4 +62,38 @@ export function updatePodfileAutolinkCall(
     match[0],
     `use_expo_modules!({ exclude: ["${exclude}"] })`
   );
+}
+
+export function updateGradleAutolinkCall(
+  contents: string,
+  { exclude }: { exclude: string }
+): string {
+  const match = contents.match(/useExpoModules\(\)/);
+  if (!match?.[0]) {
+    throw new Error(`Could not find useExpoModules() call in settings.gradle`);
+  }
+
+  if (!match[0].trim().endsWith("()")) {
+    throw new Error(
+      `expo-build-flags: settings.gradle has an unexpected useExpoModules() call format.`
+    );
+  }
+
+  const useExpoWithExclusions = `
+useExpoModules {
+  exclude = '${exclude}'
+}  
+`;
+
+  return contents.replace(match[0], useExpoWithExclusions);
+}
+
+let exclusionsString: string | null = null;
+async function getExclusions() {
+  if (typeof exclusionsString === "string") {
+    return exclusionsString;
+  }
+  const exclusions = await readConfigModuleExclusions();
+  exclusionsString = exclusions.join(",");
+  return exclusionsString;
 }

--- a/src/config-plugin/withFlaggedAutolinking.ts
+++ b/src/config-plugin/withFlaggedAutolinking.ts
@@ -1,0 +1,39 @@
+import fs from "fs";
+import path from "path";
+import { ConfigPlugin, withDangerousMod } from "@expo/config-plugins";
+
+const withFlaggedAutolinkingForApple: ConfigPlugin = (config) => {
+  return withDangerousMod(config, [
+    "ios",
+    async (config) => {
+      const podfile = path.join(
+        config.modRequest.platformProjectRoot,
+        "Podfile"
+      );
+      let contents = await fs.promises.readFile(podfile, "utf8");
+
+      return config;
+    },
+  ]);
+};
+
+export function updatePodfileAutolinkCall(
+  contents: string,
+  { exclude }: { exclude: string }
+): string {
+  const match = contents.match(/use_expo_modules!(\s*\(([^)]+)\))?/);
+  if (!match?.[0]) {
+    throw new Error(`Could not find use_expo_modules! call in Podfile`);
+  }
+
+  if (!match[0].trim().endsWith("!")) {
+    throw new Error(
+      `expo-build-flags: Podfile already passes args to use_expo_modules! and transforming this state is not yet supported.`
+    );
+  }
+
+  return contents.replace(
+    match[0],
+    `use_expo_modules!({ exclude: ["${exclude}"] })`
+  );
+}

--- a/test/test-autolinking.js
+++ b/test/test-autolinking.js
@@ -1,0 +1,58 @@
+const fs = require("fs");
+const cp = require("child_process");
+
+installExpoConfigPlugin();
+addModulesForExclusion();
+runPrebuild();
+assertPodfileLockExcludesModules();
+
+/**
+ * this install step assumes test-config-plugin runs before this spec suite
+ * and the plugin was previously installed
+ */
+function installExpoConfigPlugin() {
+  const expoConfig = JSON.parse(fs.readFileSync("app.json", "utf-8"));
+  expoConfig.expo.plugins = expoConfig.expo.plugins.map((plugin) => {
+    if (plugin === "expo-build-flags") {
+      return ["expo-build-flags", { flaggedAutolinking: true }];
+    }
+    return plugin;
+  });
+  fs.writeFileSync("app.json", JSON.stringify(expoConfig, null, 2));
+}
+
+function addModulesForExclusion() {
+  let defaultFlags = fs.readFileSync("flags.yml", "utf-8");
+  const flagWithModules = `  secretFeature:
+    modules:
+      - expo-splash-screen
+      - expo-status-bar`;
+  defaultFlags = defaultFlags.replace("  secretFeature:", flagWithModules);
+  console.log("patched flags.yml:\n\n", defaultFlags);
+  fs.writeFileSync("flags.yml", defaultFlags);
+}
+
+function runPrebuild() {
+  cp.execSync("./node_modules/.bin/expo prebuild --no-install --clean", {
+    env: {
+      ...process.env,
+      CI: 1,
+    },
+  });
+  try {
+    cp.execSync("../node_modules/.bin/pod-lockfile --project ios", {
+      stdio: "inherit",
+    });
+  } catch (e) {
+    console.error("pod-lockfile threw");
+  }
+}
+
+function assertPodfileLockExcludesModules() {
+  const podfileLock = fs.readFileSync("ios/Podfile.lock", "utf-8");
+  if (podfileLock.includes("Splash")) {
+    throw new Error("Expected ios/Podfile.lock to exclude expo-splash-screen");
+  }
+
+  console.log("Test passed!");
+}

--- a/test/test-autolinking.js
+++ b/test/test-autolinking.js
@@ -39,13 +39,9 @@ function runPrebuild() {
       CI: 1,
     },
   });
-  try {
-    cp.execSync("../node_modules/.bin/pod-lockfile --project ios", {
-      stdio: "inherit",
-    });
-  } catch (e) {
-    console.error("pod-lockfile threw");
-  }
+  cp.execSync("../node_modules/.bin/pod-lockfile --debug --project ios", {
+    stdio: "inherit",
+  });
 }
 
 function assertPodfileLockExcludesModules() {


### PR DESCRIPTION
Add support for skipping autolinking for modules tied to flags that are off by default. This allows CI for flagged features that rely on native modules which allows for shipping builds without native changes while related work is not yet code complete.