### PR TITLE
fix(autolinking): handle RN core exclusions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,33 @@ on:
       - main
 
 jobs:
+  test-sdk-52:
+    runs-on: ubuntu-latest
+    env:
+      EXPO_SDK_TARGET: 52
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "zulu"
+          java-version: "21"
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run integration for SDK 52
+        run: ./test/run-integration.sh
+
   test-sdk-51:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "zulu"
+          java-version: "21"
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.3"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To benefit from tree shaking, add the babel plugin to your project's babel confi
 
 The `flagsModule` path must match the runtime `mergePath` in your committed flags.yml file. This plugin replaces the `BuildFlags` imports with the literal boolean values which allows the build pipeline to strip unreachable paths.
 
-### Flagged Autolinking
+### Flagged Autolinking (for RN >=75)
 
 If your feature relies on native module behaviour, you may want to avoid linking that module if the build flag is off. To do so, specify the absolute name or relative path to the module in the base definition for your flag:
 
@@ -72,6 +72,8 @@ modules:
   - react-native-device-info:
       branch: some-branch-with-build
 ```
+
+In order to enable this you need to pass `flaggedAutolinking: true` as an option to the expo config plugin.
 
 Locally-referenced modules aren't currently supported (until [this 'exclude' exclusion](https://github.com/expo/expo/blob/24d5ae5f288013df19ac09a3406c6a507d781ddb/packages/expo-modules-autolinking/src/autolinking/findModules.ts#L52) can be overridden).
 

--- a/bin/build-flags-autolinking.sh
+++ b/bin/build-flags-autolinking.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../build/cli/autolinking.js')

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "yaml": "^2.5.1"
       },
       "bin": {
-        "build-flags": "bin/build-flags.sh"
+        "build-flags": "bin/build-flags.sh",
+        "build-flags-autolinking": "bin/build-flags-autolinking.sh"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.25.4",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "author": "Wes Johnson <wes@swj.io>",
   "license": "MIT",
   "bin": {
-    "build-flags": "bin/build-flags.sh"
+    "build-flags": "bin/build-flags.sh",
+    "build-flags-autolinking": "bin/build-flags-autolinking.sh"
   },
   "main": "build/api/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "scripts": {
     "build": "tsc",
     "test": "npm run test:unit && EXPO_SDK_TARGET=51 ./test/run-integration.sh",
+    "test:next": "EXPO_SDK_TARGET=52 ./test/run-integration.sh",
     "test:unit": "./node_modules/.bin/jest"
   }
 }

--- a/src/cli/autolinking.ts
+++ b/src/cli/autolinking.ts
@@ -1,0 +1,73 @@
+const commandArgs = process.argv.slice(2);
+
+const expoAutolinking = require("expo-modules-autolinking");
+
+const logMethod = console.log;
+const logCallArgs: any[] = [];
+console.log = (...args) => {
+  logCallArgs.push(args);
+};
+
+const findConfigFromArgs = (args: string[][]) => {
+  const match = args.find(
+    (arg) =>
+      Array.isArray(arg) &&
+      typeof arg[0] === "string" &&
+      arg[0][0] === "{" &&
+      arg[0][arg[0].length - 1] === "}"
+  );
+  if (!match) {
+    throw new Error(
+      "expo-build-flags autolinking CLI: No match for expected react-native-config object in stdout"
+    );
+  }
+
+  try {
+    return JSON.parse(match[0]);
+  } catch (e: any) {
+    throw new Error(
+      `expo-build-flags autolinking CLI: Failed to parse react-native-config JSON from stdout: ${e.message}`
+    );
+  }
+};
+
+type ConfigOutput = {
+  root: string;
+  reactNativePath: string;
+  project: {
+    ios?: { sourceDir: string };
+    android?: { sourceDir: string };
+  };
+  dependencies: Record<string, { name: string; root: string; platforms: any }>;
+};
+
+const getExclusions = () => {
+  return commandArgs.reduce((acc, arg, idx) => {
+    const next = commandArgs[idx + 1];
+    if (arg === "-x" && typeof next === "string") {
+      return acc.concat(next);
+    }
+    return acc;
+  }, [] as string[]);
+};
+
+const processConfig = (config: ConfigOutput) => {
+  const excludedDependencies = getExclusions();
+  const updatedConfig = {
+    ...config,
+    dependencies: Object.fromEntries(
+      Object.entries(config.dependencies).filter(([key]) => {
+        return !excludedDependencies.includes(key);
+      })
+    ),
+  };
+
+  return JSON.stringify(updatedConfig);
+};
+
+expoAutolinking(["react-native-config", "--json", "--platform", "ios"]).then(
+  () => {
+    console.log = logMethod;
+    console.log(processConfig(findConfigFromArgs(logCallArgs)));
+  }
+);

--- a/src/cli/autolinking.ts
+++ b/src/cli/autolinking.ts
@@ -41,6 +41,24 @@ type ConfigOutput = {
   dependencies: Record<string, { name: string; root: string; platforms: any }>;
 };
 
+const getPlatform = () => {
+  const platformIndex = commandArgs.indexOf("-p");
+  if (platformIndex === -1) {
+    throw new Error(
+      "expo-build-flags autolinking CLI: No platform (-p) argument provided"
+    );
+  }
+
+  const platform = commandArgs[platformIndex + 1];
+  if (platform !== "ios" && platform !== "android") {
+    throw new Error(
+      `expo-build-flags autolinking CLI: Invalid platform provided "${platform}"`
+    );
+  }
+
+  return platform;
+};
+
 const getExclusions = () => {
   return commandArgs.reduce((acc, arg, idx) => {
     const next = commandArgs[idx + 1];
@@ -65,9 +83,12 @@ const processConfig = (config: ConfigOutput) => {
   return JSON.stringify(updatedConfig);
 };
 
-expoAutolinking(["react-native-config", "--json", "--platform", "ios"]).then(
-  () => {
-    console.log = logMethod;
-    console.log(processConfig(findConfigFromArgs(logCallArgs)));
-  }
-);
+expoAutolinking([
+  "react-native-config",
+  "--json",
+  "--platform",
+  getPlatform(),
+]).then(() => {
+  console.log = logMethod;
+  console.log(processConfig(findConfigFromArgs(logCallArgs)));
+});

--- a/src/config-plugin/withFlaggedAutolinking.spec.ts
+++ b/src/config-plugin/withFlaggedAutolinking.spec.ts
@@ -1,21 +1,25 @@
 import fs from "fs";
 import { jest, describe, it, expect, beforeEach } from "@jest/globals";
 import {
-  updatePodfileAutolinkCall,
   updateGradleAutolinkCall,
+  updatePodfileReactNativeAutolinkCall,
+  updatePodfileExpoModulesAutolinkCall,
 } from "./withFlaggedAutolinking";
 
 describe("withFlaggedAutolinking", () => {
-  describe("updatePodfileAutolinkCall", () => {
+  describe("updatePodfileExpoModulesAutolinkCall", () => {
     const podfileContents = fs.readFileSync(
       "src/config-plugin/fixtures/Podfile",
       "utf8"
     );
 
     it("should replace use_expo_modules! with exclude options in call", () => {
-      const updatedContents = updatePodfileAutolinkCall(podfileContents, {
-        exclude: ["react-native-device-info"],
-      });
+      const updatedContents = updatePodfileExpoModulesAutolinkCall(
+        podfileContents,
+        {
+          exclude: ["react-native-device-info"],
+        }
+      );
       const updatedLine = updatedContents
         .split("\n")
         .find((line) =>
@@ -48,6 +52,43 @@ describe("withFlaggedAutolinking", () => {
       expect(updatedLine).toBe(
         `useExpoModules(exclude: ["react-native-device-info","some-other-module"])`
       );
+    });
+  });
+
+  describe("updatePodfileReactNativeAutolinkCall", () => {
+    const podfileContents = fs.readFileSync(
+      "src/config-plugin/fixtures/Podfile",
+      "utf8"
+    );
+
+    it("should replace origin_autolinking_method.call(config_command) with custom autolinking command", () => {
+      const updatedContents = updatePodfileReactNativeAutolinkCall(
+        podfileContents,
+        {
+          exclude: ["react-native-device-info", "react-native-reanimated"],
+        }
+      );
+      const updatedLineIndex = updatedContents
+        .split("\n")
+        .findIndex((line) =>
+          line.trim().startsWith("# expo-build-flags autolinking override")
+        );
+
+      expect(updatedLineIndex).toBeGreaterThan(-1);
+
+      const snapshotLineOffset = updatedLineIndex + 1;
+      const linesToSnapshot = 5;
+      const matchLines = updatedContents
+        .split("\n")
+        .slice(snapshotLineOffset, snapshotLineOffset + linesToSnapshot)
+        .join("\n");
+      expect(matchLines).toMatchInlineSnapshot(`
+"    config_command = [
+      './node_modules/.bin/build-flags-autolinking',
+      '-x', 'react-native-device-info', '-x', 'react-native-reanimated'
+    ]
+    origin_autolinking_method.call(config_command)"
+`);
     });
   });
 });

--- a/src/config-plugin/withFlaggedAutolinking.spec.ts
+++ b/src/config-plugin/withFlaggedAutolinking.spec.ts
@@ -3,7 +3,7 @@ import { jest, describe, it, expect, beforeEach } from "@jest/globals";
 import {
   updateGradleReactNativeAutolinkCall,
   updateGradleExpoModulesAutolinkCall,
-  updatePodfileReactNativeAutolinkCall,
+  updatePodfileReactNativeAutolinkCallForSDK51,
   updatePodfileExpoModulesAutolinkCall,
 } from "./withFlaggedAutolinking";
 
@@ -96,14 +96,14 @@ describe("withFlaggedAutolinking", () => {
     });
   });
 
-  describe("updatePodfileReactNativeAutolinkCall", () => {
+  describe("updatePodfileReactNativeAutolinkCallForSDK51", () => {
     const podfileContents = fs.readFileSync(
       "src/config-plugin/fixtures/Podfile",
       "utf8"
     );
 
     it("should replace origin_autolinking_method.call(config_command) with custom autolinking command", () => {
-      const updatedContents = updatePodfileReactNativeAutolinkCall(
+      const updatedContents = updatePodfileReactNativeAutolinkCallForSDK51(
         podfileContents,
         {
           exclude: ["react-native-device-info", "react-native-reanimated"],

--- a/src/config-plugin/withFlaggedAutolinking.spec.ts
+++ b/src/config-plugin/withFlaggedAutolinking.spec.ts
@@ -84,7 +84,7 @@ describe("withFlaggedAutolinking", () => {
         .join("\n");
       expect(matchLines).toMatchInlineSnapshot(`
 "    config_command = [
-      './node_modules/.bin/build-flags-autolinking',
+      '../node_modules/.bin/build-flags-autolinking',
       '-x', 'react-native-device-info', '-x', 'react-native-reanimated'
     ]
     origin_autolinking_method.call(config_command)"

--- a/src/config-plugin/withFlaggedAutolinking.ts
+++ b/src/config-plugin/withFlaggedAutolinking.ts
@@ -66,7 +66,7 @@ export function updatePodfileReactNativeAutolinkCall(
     `
     # expo-build-flags autolinking override
     config_command = [
-      './node_modules/.bin/build-flags-autolinking',
+      '../node_modules/.bin/build-flags-autolinking',
       ${exclude.map((dep) => [`'-x'`, `'${dep}'`].join(", ")).join(", ")}
     ]
     ${matchPoint}

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -10,16 +10,18 @@ fi
 
 npm run build
 
-if [ "$EXPO_SDK_TARGET" -eq "51" ]; then
-  export EXPO_UNSTABLE_CORE_AUTOLINKING=1
-fi
-
 echo "Creating expo app"
 rm -rf example
 CI=1 npx create-expo-app --template "expo-template-default@$EXPO_SDK_TARGET" example
 
 echo "Installing library"
 cd example
+
+if [ "$EXPO_SDK_TARGET" -eq "51" ]; then
+  echo "Using expo SDK 51 with react-native 0.75.0"
+  npm install --save react-native@~0.75.0
+fi
+
 npm install --install-links --save-dev ../
 
 echo "copy over flag fixture"

--- a/test/setup.sh
+++ b/test/setup.sh
@@ -10,6 +10,10 @@ fi
 
 npm run build
 
+if [ "$EXPO_SDK_TARGET" -eq "51" ]; then
+  export EXPO_UNSTABLE_CORE_AUTOLINKING=1
+fi
+
 echo "Creating expo app"
 rm -rf example
 CI=1 npx create-expo-app --template "expo-template-default@$EXPO_SDK_TARGET" example

--- a/test/test-autolinking.js
+++ b/test/test-autolinking.js
@@ -83,7 +83,7 @@ function assertPodfileLockExcludesModules() {
     throw new Error("Expected ios/Podfile.lock to exclude expo-splash-screen");
   }
 
-  console.log("Test passed!");
+  console.log("assertPodfileLockExcludesModules passed!");
 }
 
 function assertGradleProjectExcludesModules() {
@@ -116,7 +116,7 @@ function assertGradleProjectExcludesModules() {
           return;
         }
 
-        console.log("Test passed!");
+        console.log("assertGradleProjectExcludesModules passed!");
         resolve();
       }
     );

--- a/test/test-autolinking.js
+++ b/test/test-autolinking.js
@@ -99,6 +99,13 @@ function assertGradleProjectExcludesModules() {
       (error, stdout, stderr) => {
         console.log(stdout);
 
+        if (!stdout.includes("+--- Project ':app'")) {
+          reject(
+            new Error("Expected android project to include base project ':app'")
+          );
+          return;
+        }
+
         if (stdout.includes("+--- Project ':react-native-reanimated'")) {
           reject(
             new Error(
@@ -107,6 +114,8 @@ function assertGradleProjectExcludesModules() {
           );
           return;
         }
+
+        console.log("Test passed!");
         resolve();
       }
     );

--- a/test/test-autolinking.js
+++ b/test/test-autolinking.js
@@ -39,6 +39,7 @@ function addModulesForExclusion() {
 
 async function runAsync() {
   await runPrebuild();
+  await logEnv();
   await assertPodfileLockExcludesModules();
   await assertGradleProjectExcludesModules();
   process.exit(0);
@@ -116,6 +117,19 @@ function assertGradleProjectExcludesModules() {
         }
 
         console.log("Test passed!");
+        resolve();
+      }
+    );
+  });
+}
+
+function logEnv() {
+  return new Promise((resolve) => {
+    cp.exec(
+      "cd android && ./gradlew -v",
+      { stdio: "inherit" },
+      (error, stdout, stderr) => {
+        console.log(stdout);
         resolve();
       }
     );

--- a/test/test-autolinking.js
+++ b/test/test-autolinking.js
@@ -59,6 +59,10 @@ async function runPrebuild() {
 
   cp.execSync("../node_modules/.bin/pod-lockfile --debug --project ios", {
     stdio: "inherit",
+    env: {
+      ...process.env,
+      EXPO_UNSTABLE_CORE_AUTOLINKING: "1",
+    },
   });
 }
 

--- a/test/test-autolinking.js
+++ b/test/test-autolinking.js
@@ -40,6 +40,7 @@ function addModulesForExclusion() {
 async function runAsync() {
   await runPrebuild();
   await assertPodfileLockExcludesModules();
+  await assertGradleProjectExcludesModules();
   process.exit(0);
 }
 
@@ -82,4 +83,32 @@ function assertPodfileLockExcludesModules() {
   }
 
   console.log("Test passed!");
+}
+
+function assertGradleProjectExcludesModules() {
+  return new Promise((resolve, reject) => {
+    cp.exec(
+      "cd android && ./gradlew projects --console=plain",
+      {
+        stdio: "inherit",
+        env: {
+          ...process.env,
+          EXPO_UNSTABLE_CORE_AUTOLINKING: "1",
+        },
+      },
+      (error, stdout, stderr) => {
+        console.log(stdout);
+
+        if (stdout.includes("+--- Project ':react-native-reanimated'")) {
+          reject(
+            new Error(
+              "Expected android project to exclude react-native-reanimated"
+            )
+          );
+          return;
+        }
+        resolve();
+      }
+    );
+  });
 }

--- a/test/test-autolinking.js
+++ b/test/test-autolinking.js
@@ -30,7 +30,8 @@ function addModulesForExclusion() {
   const flagWithModules = `  secretFeature:
     modules:
       - expo-splash-screen
-      - expo-status-bar`;
+      - expo-status-bar
+      - react-native-reanimated`;
   defaultFlags = defaultFlags.replace("  secretFeature:", flagWithModules);
   console.log("patched flags.yml:\n\n", defaultFlags);
   fs.writeFileSync("flags.yml", defaultFlags);
@@ -63,6 +64,15 @@ async function runPrebuild() {
 
 function assertPodfileLockExcludesModules() {
   const podfileLock = fs.readFileSync("ios/Podfile.lock", "utf-8");
+
+  // assertion for core linking exclusion
+  if (podfileLock.includes("Reanimated")) {
+    throw new Error(
+      "Expected ios/Podfile.lock to exclude react-native-reanimated"
+    );
+  }
+
+  // assertion for expo linking exclusion
   if (podfileLock.includes("Splash")) {
     throw new Error("Expected ios/Podfile.lock to exclude expo-splash-screen");
   }


### PR DESCRIPTION
flagged autolinking supported for:

- [x] iOS w/ expo SDK 51 + RN 75
- [x] iOS w/ expo SDK 52 + RN 76
- [x] Android w/ expo SDK 51 + RN 75
- [x] Android w/ expo SDK 52 + RN 76

Note in the readme that RN 74 is not supported as podfile use_native_modules changes are not in core from community CLI