### PR TITLE
fix(cli): adds skip override flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The arguments after the override command are the flags you want to `+` enable or
 
 You can run `yarn build-flags ota-override` instead of "override" to do the same but also consider the branch name in two supported CI environments: Github and Gitlab. Use the `ota.branches` array in the flags.yml to setup that matching and branch-based enablement.
 
+Use `--skip-if-env <ENV_VAR>` to skip the override command when a certain environment variable is set. This can be useful in CI job runs.
+
 ### Set Flags in CI & for Static Builds
 
 To set flags for EAS builds, set the `EXPO_BUILD_FLAGS` environment variable in `eas.json` for your profile. This value will be available to the config plugin at build time in EAS when you add it to your `app.json` plugins array:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The arguments after the override command are the flags you want to `+` enable or
 
 You can run `yarn build-flags ota-override` instead of "override" to do the same but also consider the branch name in two supported CI environments: Github and Gitlab. Use the `ota.branches` array in the flags.yml to setup that matching and branch-based enablement.
 
-Use `--skip-if-env <ENV_VAR>` to skip the override command when a certain environment variable is set. This can be useful in CI job runs.
+Use `--skip-if-env <ENV_VAR_NAME>` passing the name of the environment variable to check. If the variable has a truthy value the CLI command will be a no-op/skipped. This can be useful in CI contexts like EAS where other processes may handle generating the runtime build flags. In the case of EAS you could use `--skip-if-env EAS_BUILD`
 
 ### Set Flags in CI & for Static Builds
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-build-flags",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "repository": "https://github.com/fullscript/expo-build-flags",
   "author": "Wes Johnson <wes.johnson@fullscript.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expo-build-flags",
-  "version": "0.8.3",
+  "version": "0.8.2",
   "repository": "https://github.com/fullscript/expo-build-flags",
   "author": "Wes Johnson <wes.johnson@fullscript.com>",
   "license": "MIT",

--- a/src/cli/main.spec.ts
+++ b/src/cli/main.spec.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "@jest/globals";
+import { getOptionValue, parseArgs } from "./main";
+
+describe("getOptionValue", () => {
+  it("should return the value after the option", () => {
+    const args = ["yarn", "build-flags", "--skip-if-env", "EAS_BUILD"];
+    expect(getOptionValue(args, "--skip-if-env")).toBe("EAS_BUILD");
+  });
+
+  it("should return undefined if option is not present", () => {
+    const args = ["yarn", "build-flags", "override", "+flag"];
+    expect(getOptionValue(args, "--skip-if-env")).toBeUndefined();
+  });
+
+  it("should return undefined if option is last argument (no value)", () => {
+    const args = ["yarn", "build-flags","+flag", "--skip-if-env"];
+    expect(getOptionValue(args, "--skip-if-env")).toBeUndefined();
+  });
+});
+
+describe("parseArgs", () => {
+  describe("command parsing", () => {
+    it("should parse override command", () => {
+      const args = ["yarn", "build-flags", "override"];
+      const result = parseArgs(args);
+      expect(result.command).toBe("override");
+    });
+
+    it("should parse init command", () => {
+      const args = ["yarn", "build-flags", "init"];
+      const result = parseArgs(args);
+      expect(result.command).toBe("init");
+    });
+
+    it("should parse ota-override command", () => {
+      const args = ["yarn", "build-flags", "ota-override"];
+      const result = parseArgs(args);
+      expect(result.command).toBe("ota-override");
+    });
+  });
+
+  describe("flag parsing", () => {
+    it("should parse flags to enable with + prefix", () => {
+      const args = ["yarn", "build-flags", "override", "+feature1", "+feature2"];
+      const result = parseArgs(args);
+      expect(result.flagsToEnable).toEqual(new Set(["feature1", "feature2"]));
+    });
+
+    it("should parse flags to disable with - prefix", () => {
+      const args = ["yarn", "build-flags", "override", "-feature1", "-feature2"];
+      const result = parseArgs(args);
+      expect(result.flagsToDisable).toEqual(new Set(["feature1", "feature2"]));
+    });
+
+    it("should parse mixed enable and disable flags", () => {
+      const args = [
+        "yarn",
+        "build-flags",
+        "override",
+        "+enableThis",
+        "-disableThis",
+      ];
+      const result = parseArgs(args);
+      expect(result.flagsToEnable).toEqual(new Set(["enableThis"]));
+      expect(result.flagsToDisable).toEqual(new Set(["disableThis"]));
+    });
+  });
+
+  describe("--skip-if-env option", () => {
+    it("should extract skipIfEnv when option comes after command", () => {
+      const args = [
+        "yarn",
+        "build-flags",
+        "override",
+        "--skip-if-env",
+        "EAS_BUILD",
+      ];
+      const result = parseArgs(args);
+      expect(result.skipIfEnv).toBe("EAS_BUILD");
+      expect(result.command).toBe("override");
+    });
+
+    it("should handle flags alongside --skip-if-env", () => {
+      const args = [
+        "yarn",
+        "build-flags",
+        "override",
+        "+feature",
+        "--skip-if-env",
+        "CI",
+        "-other",
+      ];
+      const result = parseArgs(args);
+      expect(result.command).toBe("override");
+      expect(result.skipIfEnv).toBe("CI");
+      expect(result.flagsToEnable).toEqual(new Set(["feature"]));
+      expect(result.flagsToDisable).toEqual(new Set(["other"]));
+    });
+
+    it("should return undefined skipIfEnv when option is not provided", () => {
+      const args = ["yarn", "build-flags", "override", "+flag"];
+      const result = parseArgs(args);
+      expect(result.skipIfEnv).toBeUndefined();
+    });
+  });
+});
+

--- a/src/cli/main.spec.ts
+++ b/src/cli/main.spec.ts
@@ -1,22 +1,5 @@
 import { describe, it, expect } from "@jest/globals";
-import { getOptionValue, parseArgs } from "./main";
-
-describe("getOptionValue", () => {
-  it("should return the value after the option", () => {
-    const args = ["yarn", "build-flags", "--skip-if-env", "EAS_BUILD"];
-    expect(getOptionValue(args, "--skip-if-env")).toBe("EAS_BUILD");
-  });
-
-  it("should return undefined if option is not present", () => {
-    const args = ["yarn", "build-flags", "override", "+flag"];
-    expect(getOptionValue(args, "--skip-if-env")).toBeUndefined();
-  });
-
-  it("should return undefined if option is last argument (no value)", () => {
-    const args = ["yarn", "build-flags","+flag", "--skip-if-env"];
-    expect(getOptionValue(args, "--skip-if-env")).toBeUndefined();
-  });
-});
+import { parseArgs } from "./main";
 
 describe("parseArgs", () => {
   describe("command parsing", () => {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -9,6 +9,14 @@ export const getOptionValue = (args: string[], option: string): string | undefin
   return index !== -1 ? args[index + 1] : undefined;
 };
 
+export const shouldSkip = (envKey: string | undefined): boolean => {
+  if (envKey && process.env[envKey] !== undefined) {
+    console.log(`Skipping build-flags override because ${envKey} is set in environment`);
+    return true;
+  }
+  return false;
+};
+
 export const parseArgs = (args: string[]) => {
   let command;
   const flagsToDisable = new Set<string>();
@@ -101,10 +109,7 @@ const run = async () => {
   }
 
   if (command === "override") {
-    if (skipIfEnv && process.env[skipIfEnv] !== undefined) {
-      console.log(
-        `Skipping build-flags override because ${skipIfEnv} is set in environment`
-      );
+    if (shouldSkip(skipIfEnv)) {
       return;
     }
     await generateOverrides({ flagsToEnable, flagsToDisable });

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -18,7 +18,7 @@ export const parseArgs = (args: string[]) => {
   const flagsToDisable = new Set<string>();
   const flagsToEnable = new Set<string>();
 
-  const argsCopy = [...args].slice(2);
+  const argsCopy = args.slice(2);
   const skipIfEnvIndex = argsCopy.indexOf("--skip-if-env");
   if (skipIfEnvIndex !== -1) {
     skipIfEnv = argsCopy[skipIfEnvIndex + 1];

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -4,11 +4,6 @@ import { readFile, writeFile } from "fs/promises";
 import { BuildFlags } from "../api/BuildFlags";
 import { generateOverrides } from "../api/generateOverrides";
 
-export const getOptionValue = (args: string[], option: string): string | undefined => {
-  const index = args.indexOf(option);
-  return index !== -1 ? args[index + 1] : undefined;
-};
-
 export const shouldSkip = (envKey: string | undefined): boolean => {
   if (envKey && process.env[envKey] !== undefined) {
     console.log(`Skipping build-flags override because ${envKey} is set in environment`);
@@ -19,20 +14,18 @@ export const shouldSkip = (envKey: string | undefined): boolean => {
 
 export const parseArgs = (args: string[]) => {
   let command;
+  let skipIfEnv: string | undefined;
   const flagsToDisable = new Set<string>();
   const flagsToEnable = new Set<string>();
 
-  const skipIfEnv = getOptionValue(args, "--skip-if-env");
+  const argsCopy = [...args].slice(2);
+  const skipIfEnvIndex = argsCopy.indexOf("--skip-if-env");
+  if (skipIfEnvIndex !== -1) {
+    skipIfEnv = argsCopy[skipIfEnvIndex + 1];
+    argsCopy.splice(skipIfEnvIndex, 2);
+  }
 
-  const skipIfEnvIndex = args.indexOf("--skip-if-env");
-  const filteredArgs = args
-    .slice(2)
-    .filter((_, i) => {
-      const originalIndex = i + 2;
-      return originalIndex !== skipIfEnvIndex && originalIndex !== skipIfEnvIndex + 1;
-    });
-
-  filteredArgs.forEach((arg) => {
+  argsCopy.forEach((arg) => {
     if (arg.startsWith("-")) {
       flagsToDisable.add(arg.replace("-", ""));
       return;

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -6,7 +6,7 @@ import { generateOverrides } from "../api/generateOverrides";
 
 export const shouldSkip = (envKey: string | undefined): boolean => {
   if (envKey && process.env[envKey] !== undefined) {
-    console.log(`Skipping build-flags override because ${envKey} is set in environment`);
+    console.log(`Skipping build-flags command because ${envKey} is set in environment (--skip-if-env)`);
     return true;
   }
   return false;

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -103,15 +103,16 @@ const run = async () => {
     process.argv
   );
 
+  if (shouldSkip(skipIfEnv)) {
+    return;
+  }
+  
   if (command === "init") {
     await initFlagsFile();
     return;
   }
 
   if (command === "override") {
-    if (shouldSkip(skipIfEnv)) {
-      return;
-    }
     await generateOverrides({ flagsToEnable, flagsToDisable });
     return;
   }


### PR DESCRIPTION
## Add `--skip-if-env` option to override command

### Summary
Adds a new `--skip-if-env <ENV_VAR>` option to the `override` command that skips execution when the specified environment variable is set.

### Usage
yarn build-flags override --skip-if-env EAS_BUILD +localFlag -otherFlagWhen `EAS_BUILD` is set in the environment, the command logs a skip message and exits without modifying flags.

### Changes
- Added `getOptionValue` helper to extract option values from args
- Updated `parseArgs` to handle `--skip-if-env` option
- Added skip logic in the `override` command handler
- Updated help text with new option
- Added unit tests for argument parsing
- Updated README documentation