### PR TITLE
fix(android): config plugin build flag module override

### DIFF
--- a/test/overrides/default-flags.yml
+++ b/test/overrides/default-flags.yml
@@ -1,5 +1,9 @@
 mergePath: "constants/buildFlags.ts"
 flags:
+  secretAndroidFeature:
+    value: false
+    meta:
+      team: "platform"
   secretFeature:
     value: false
     meta:

--- a/test/overrides/expected-api-override.ts
+++ b/test/overrides/expected-api-override.ts
@@ -1,5 +1,6 @@
 export const BuildFlags = {
     newFeature: true,
     publishedFeatured: true,
+    secretAndroidFeature: false,
     secretFeature: false
 };

--- a/test/overrides/expected-cli-override.ts
+++ b/test/overrides/expected-cli-override.ts
@@ -1,5 +1,6 @@
 export const BuildFlags = {
     newFeature: false,
     publishedFeatured: true,
+    secretAndroidFeature: false,
     secretFeature: true
 };

--- a/test/run-integration.sh
+++ b/test/run-integration.sh
@@ -2,12 +2,12 @@
 
 set -e
 
-function logMark () {
-  echo ""
-  echo "###################################################################"
-  echo "$1"
-  echo "###################################################################"
-  echo ""
+function logMark() {
+	echo ""
+	echo "###################################################################"
+	echo "$1"
+	echo "###################################################################"
+	echo ""
 }
 
 logMark "Setting up test environment"
@@ -23,6 +23,9 @@ node ../test/test-babel-plugin.js
 
 logMark "Running test-config-plugin.js"
 node ../test/test-config-plugin.js
+
+logMark "Running test-config-plugin-android.js"
+node ../test/test-config-plugin-android.js
 
 logMark "Running test-autolinking.js"
 node ../test/test-autolinking.js

--- a/test/run-integration.sh
+++ b/test/run-integration.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+#
+# WARNING - these tests build on top of each other
+# adjust your initial test flag state accordingly
+#
+
 set -e
 
 function logMark() {

--- a/test/test-config-plugin-android.js
+++ b/test/test-config-plugin-android.js
@@ -7,26 +7,15 @@ export const BuildFlags = {
     bundleIdScopedFeature: true,
     newFeature: true,
     publishedFeatured: true,
-    secretFeature: true
+    secretAndroidFeature: true,
+    secretFeature: false
 };
-`;
-
-const expectedManifestTag =
-  '<meta-data android:name="EXBuildFlags" android:value="secretFeature,newFeature"/>';
-
-const expectedPlistFlagArray = `
-    <key>EXBuildFlags</key>
-    <array>
-      <string>secretFeature</string>
-      <string>newFeature</string>
-    </array>
 `;
 
 addBundleIdScopedFlag();
 installExpoConfigPlugin();
 runPrebuild();
 assertFlagsAllTrue();
-assertAndroidManifest();
 
 function addBundleIdScopedFlag() {
   const flagsYmlString = fs.readFileSync("flags.yml", { encoding: "utf-8" });
@@ -53,7 +42,7 @@ function runPrebuild() {
     env: {
       ...process.env,
       CI: 1,
-      EXPO_BUILD_FLAGS: "secretFeature,newFeature",
+      EXPO_BUILD_FLAGS: "secretAndroidFeature",
     },
   });
 }
@@ -77,21 +66,5 @@ function assertFlagsAllTrue() {
 
   console.log(
     "Assertion passed: Runtime build flags enabled by config plugin!"
-  );
-}
-
-function assertAndroidManifest() {
-  const fileContents = fs.readFileSync(
-    "android/app/src/main/AndroidManifest.xml",
-    "utf8"
-  );
-  if (!fileContents.includes(expectedManifestTag)) {
-    throw new Error(
-      "Expected AndroidManifest.xml to contain EXBuildFlags meta-data tag"
-    );
-  }
-
-  console.log(
-    "Assertion passed: AndroidManifest.xml updated by config plugin!"
   );
 }

--- a/test/test-config-plugin-android.js
+++ b/test/test-config-plugin-android.js
@@ -1,0 +1,97 @@
+const fs = require("fs");
+const cp = require("child_process");
+const yaml = require("yaml");
+
+const expectedRuntimeModule = `
+export const BuildFlags = {
+    bundleIdScopedFeature: true,
+    newFeature: true,
+    publishedFeatured: true,
+    secretFeature: true
+};
+`;
+
+const expectedManifestTag =
+  '<meta-data android:name="EXBuildFlags" android:value="secretFeature,newFeature"/>';
+
+const expectedPlistFlagArray = `
+    <key>EXBuildFlags</key>
+    <array>
+      <string>secretFeature</string>
+      <string>newFeature</string>
+    </array>
+`;
+
+addBundleIdScopedFlag();
+installExpoConfigPlugin();
+runPrebuild();
+assertFlagsAllTrue();
+assertAndroidManifest();
+
+function addBundleIdScopedFlag() {
+  const flagsYmlString = fs.readFileSync("flags.yml", { encoding: "utf-8" });
+  const flagConfig = yaml.parse(flagsYmlString);
+  flagConfig.flags.bundleIdScopedFeature = {
+    value: false,
+    invertFor: {
+      bundleId: ["com.example.app"],
+    },
+  };
+  fs.writeFileSync("flags.yml", yaml.stringify(flagConfig));
+}
+
+function installExpoConfigPlugin() {
+  const expoConfig = JSON.parse(fs.readFileSync("app.json", "utf-8"));
+  expoConfig.expo.plugins.push("expo-build-flags");
+  expoConfig.expo.ios.bundleIdentifier = "com.example.app";
+  expoConfig.expo.android.package = "com.example.app";
+  fs.writeFileSync("app.json", JSON.stringify(expoConfig, null, 2));
+}
+
+function runPrebuild() {
+  cp.execSync("./node_modules/.bin/expo prebuild -p android --clean", {
+    env: {
+      ...process.env,
+      CI: 1,
+      EXPO_BUILD_FLAGS: "secretFeature,newFeature",
+    },
+  });
+}
+
+function assertFlagsAllTrue() {
+  const fileContents = fs.readFileSync("constants/buildFlags.ts", "utf8");
+  if (fileContents.trim() !== expectedRuntimeModule.trim()) {
+    console.log(
+      "received:\n\n",
+      `>${fileContents.trim()}<`,
+      "\n\n",
+      "expected:\n\n",
+      `>${expectedRuntimeModule.trim()}<`,
+      "\n\n"
+    );
+
+    throw new Error(
+      "Expected runtime buildFlags.ts module to contain all flags as true"
+    );
+  }
+
+  console.log(
+    "Assertion passed: Runtime build flags enabled by config plugin!"
+  );
+}
+
+function assertAndroidManifest() {
+  const fileContents = fs.readFileSync(
+    "android/app/src/main/AndroidManifest.xml",
+    "utf8"
+  );
+  if (!fileContents.includes(expectedManifestTag)) {
+    throw new Error(
+      "Expected AndroidManifest.xml to contain EXBuildFlags meta-data tag"
+    );
+  }
+
+  console.log(
+    "Assertion passed: AndroidManifest.xml updated by config plugin!"
+  );
+}

--- a/test/test-config-plugin.js
+++ b/test/test-config-plugin.js
@@ -7,6 +7,7 @@ export const BuildFlags = {
     bundleIdScopedFeature: true,
     newFeature: true,
     publishedFeatured: true,
+    secretAndroidFeature: false,
     secretFeature: true
 };
 `;


### PR DESCRIPTION
Due to dangerous mod platform param set to iOS only, the bundle module wasn't being generated on Android during prebuild